### PR TITLE
Fix uv not found error in daily collection script

### DIFF
--- a/scripts/daily_collection.sh
+++ b/scripts/daily_collection.sh
@@ -12,6 +12,9 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
 
+# Set up proper PATH for cron jobs (includes common locations for uv)
+export PATH="$HOME/.local/bin:/opt/homebrew/bin:/usr/local/bin:$PATH"
+
 # Create logs directory
 LOG_DIR="$PROJECT_DIR/logs"
 mkdir -p "$LOG_DIR"


### PR DESCRIPTION
## Summary
- Fix "uv is not installed" error when running daily collection via cron
- Add proper PATH setup in daily_collection.sh for cron environment
- Resolves PATH issues where uv is installed in ~/.local/bin

## Changes
- Added PATH export to include common uv installation locations
- Tested successfully - script now completes without errors

## Test plan
- [x] Manual script execution works correctly
- [x] Script finds uv and completes article collection
- [x] Database operations complete successfully
- [x] No errors in script execution

🤖 Generated with [Claude Code](https://claude.ai/code)